### PR TITLE
Get full text for tweets with >140 symbols

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const defaults = {
   trim_user: true,
   include_rts: true,
   exclude_replies: false,
+  tweet_mode: 'extended',
 };
 
 function getNextOptions(options, tweets) {


### PR DESCRIPTION
According to https://developer.twitter.com/en/docs/tweets/tweet-updates.html if we want get full information for tweets containing more than 140 characters, we need to pass `tweet_mode=extended` option.